### PR TITLE
create testcase for http test

### DIFF
--- a/src/vaddy/config/config.go
+++ b/src/vaddy/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const VERSION string = "1.1.0"
+const VERSION string = "1.1.1"
 
 const LIMIT_WAIT_COUNT int = 1260 // 20sec * 1260 = 7 hours
 const NETWORK_RETRY_COUNT int = 5

--- a/src/vaddy/crawl/search_crawl.go
+++ b/src/vaddy/crawl/search_crawl.go
@@ -2,7 +2,6 @@ package crawl
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"strconv"
 	"vaddy/args"
@@ -21,24 +20,23 @@ type CrawlSearchItem struct {
 
 var httpRequestHandler httpreq.HttpReqInterface = httpreq.HttpRequestData{}
 
-func GetCrawlId(scanSetting args.ScanSetting) (string, error) {
+func GetCrawlId(scanSetting args.ScanSetting) (string, int, error) {
 	json_response, err := doCrawlSearch(scanSetting)
 	//fmt.Println(string(json_response))
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	var crawl_result CrawlSearch
 	json_err := common.ConvertJsonToStruct(json_response, &crawl_result)
 	if json_err != nil {
-		return "", errors.New("Can not convert json response in crawl search.")
+		return "", 0, errors.New("Can not convert json response in crawl search.")
 	}
 	if crawl_result.Total == 0 {
-		return "", errors.New("can not find crawl id. using latest crawl id.")
+		return "", 0, errors.New("Can not find crawl id. using latest crawl id.")
 	}
 	var crawl_id int = crawl_result.Items[0].CrawlId
-	fmt.Printf("Found %d results. Using CrawlID: %d \n\n", crawl_result.Total, crawl_id)
-	return strconv.Itoa(crawl_id), nil
+	return strconv.Itoa(crawl_id), crawl_result.Total, nil
 }
 
 func doCrawlSearch(scanSetting args.ScanSetting) ([]byte, error) {

--- a/src/vaddy/crawl/search_crawl.go
+++ b/src/vaddy/crawl/search_crawl.go
@@ -20,7 +20,7 @@ type CrawlSearchItem struct {
 
 var httpRequestHandler httpreq.HttpReqInterface = httpreq.HttpRequestData{}
 
-func GetCrawlId(scanSetting args.ScanSetting) (string, int, error) {
+func GetCrawlId(scanSetting args.ScanSetting) (crawlIdString string, crawlResultTotal int, errorVal error) {
 	json_response, err := doCrawlSearch(scanSetting)
 	//fmt.Println(string(json_response))
 	if err != nil {
@@ -39,7 +39,7 @@ func GetCrawlId(scanSetting args.ScanSetting) (string, int, error) {
 	return strconv.Itoa(crawl_id), crawl_result.Total, nil
 }
 
-func doCrawlSearch(scanSetting args.ScanSetting) ([]byte, error) {
+func doCrawlSearch(scanSetting args.ScanSetting) (crawlSearchResponseJson []byte, errorVal error) {
 	values := url.Values{}
 	values.Add("user", scanSetting.User)
 	values.Add("fqdn", scanSetting.Fqdn)

--- a/src/vaddy/crawl/search_crawl.go
+++ b/src/vaddy/crawl/search_crawl.go
@@ -19,8 +19,10 @@ type CrawlSearchItem struct {
 	CrawlId int `json:"id"`
 }
 
-func GetCrawlId(httpReq httpreq.HttpRequestData, scanSetting args.ScanSetting) (string, error) {
-	json_response, err := doCrawlSearch(httpReq, scanSetting)
+var httpRequestHandler httpreq.HttpReqInterface = httpreq.HttpRequestData{}
+
+func GetCrawlId(scanSetting args.ScanSetting) (string, error) {
+	json_response, err := doCrawlSearch(scanSetting)
 	//fmt.Println(string(json_response))
 	if err != nil {
 		return "", err
@@ -39,7 +41,7 @@ func GetCrawlId(httpReq httpreq.HttpRequestData, scanSetting args.ScanSetting) (
 	return strconv.Itoa(crawl_id), nil
 }
 
-func doCrawlSearch(httpReq httpreq.HttpRequestData, scanSetting args.ScanSetting) ([]byte, error) {
+func doCrawlSearch(scanSetting args.ScanSetting) ([]byte, error) {
 	values := url.Values{}
 	values.Add("user", scanSetting.User)
 	values.Add("fqdn", scanSetting.Fqdn)
@@ -47,7 +49,7 @@ func doCrawlSearch(httpReq httpreq.HttpRequestData, scanSetting args.ScanSetting
 	values.Add("verification_code", scanSetting.VerificationCode)
 	values.Add("project_id", scanSetting.ProjectId)
 
-	result, err := httpReq.HttpGet("/crawl", scanSetting, values)
+	result, err := httpRequestHandler.HttpGet("/crawl", scanSetting, values)
 	if err != nil {
 		return nil, err
 	}

--- a/src/vaddy/crawl/search_crawl_test.go
+++ b/src/vaddy/crawl/search_crawl_test.go
@@ -1,0 +1,36 @@
+package crawl
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"vaddy/args"
+	"vaddy/httpreq"
+	"vaddy/test/mock/httpreqmock"
+)
+
+func TestName1(t *testing.T) {
+	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{200, []byte("result body"), nil}
+	httpreqmock.HttpResponseMockErr = nil
+	//httpreqmock.HttpResponseMockErr = errors.New("aa")
+
+	httpRequestHandler = httpreqmock.HttpRequestData{} //search_crawl.go global var HttpRequestHander
+	scanSetting := args.ScanSetting{}
+	result, err := doCrawlSearch(scanSetting)
+	fmt.Println(result)
+	if err != nil {
+		t.Fail()
+	}
+}
+func TestName2(t *testing.T) {
+	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{200, []byte("result body"), nil}
+	httpreqmock.HttpResponseMockErr = errors.New("aa")
+
+	httpRequestHandler = httpreqmock.HttpRequestData{}
+	scanSetting := args.ScanSetting{}
+	result, err := doCrawlSearch(scanSetting)
+	fmt.Println(result)
+	if err != nil {
+		t.Fail()
+	}
+}

--- a/src/vaddy/crawl/search_crawl_test.go
+++ b/src/vaddy/crawl/search_crawl_test.go
@@ -9,28 +9,77 @@ import (
 	"vaddy/test/mock/httpreqmock"
 )
 
-func TestName1(t *testing.T) {
-	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{200, []byte("result body"), nil}
+//Crawl検索で3件取得し、その中のItemの先頭のid:2が返ることを確認する
+// total countが3件というのも確認する
+func TestGetCrawlIdOkCrawlId2(t *testing.T) {
+	var jsonResponse string = `{"total":3,"page":1,"limit":30,
+	"items":[
+		{"id":2, "label": "all-data", "start":"2016-03-12T11:11:11+0000", "end":"2016-03-12T12:00:00+0000"},
+		{"id":1, "label": null, "start":"2016-03-12T11:11:11+0000", "end":"2016-03-12T12:00:00+0000"},
+		{"id":3, "label": null, "start":"2016-03-12T11:11:11+0000", "end":"2016-03-12T12:00:00+0000"}
+	]}`
+	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{200, []byte(jsonResponse), nil}
 	httpreqmock.HttpResponseMockErr = nil
-	//httpreqmock.HttpResponseMockErr = errors.New("aa")
 
 	httpRequestHandler = httpreqmock.HttpRequestData{} //search_crawl.go global var HttpRequestHander
 	scanSetting := args.ScanSetting{}
-	result, err := doCrawlSearch(scanSetting)
-	fmt.Println(result)
+	crawlId, count, err := GetCrawlId(scanSetting)
 	if err != nil {
-		t.Fail()
+		t.Error("err is not nil")
+	}
+	if crawlId != "2" {
+		t.Error("crawlId not 2")
+	}
+	if count != 3 {
+		t.Error("crawl count not 3")
 	}
 }
-func TestName2(t *testing.T) {
-	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{200, []byte("result body"), nil}
-	httpreqmock.HttpResponseMockErr = errors.New("aa")
+
+//Crawl検索で0件だったためエラーとなるのをテスト
+func TestGetCrawlIdNoItemError(t *testing.T) {
+	var jsonResponse string = `{"total":0,"page":1,"limit":30,
+	"items":[
+	]}`
+	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{200, []byte(jsonResponse), nil}
+	httpreqmock.HttpResponseMockErr = nil
+
+	httpRequestHandler = httpreqmock.HttpRequestData{} //search_crawl.go global var HttpRequestHander
+	scanSetting := args.ScanSetting{}
+	_, _, err := GetCrawlId(scanSetting)
+	if err == nil {
+		t.Error("err is nil")
+	}
+	if err.Error() != `Can not find crawl id. using latest crawl id.` {
+		t.Fatal("Expect no item error")
+	}
+}
+
+//レスポンスのJSONがJSON形式ではないためJSON convert errorとなるかチェック
+func TestGetCrawlIdNotJsonDataError(t *testing.T) {
+	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{200, []byte("not json data"), nil}
+	httpreqmock.HttpResponseMockErr = nil
+
+	httpRequestHandler = httpreqmock.HttpRequestData{} //search_crawl.go global var HttpRequestHander
+	scanSetting := args.ScanSetting{}
+	_, _, err := GetCrawlId(scanSetting)
+	if err == nil {
+		t.Error("err is nil")
+	}
+	if err.Error() != `Can not convert json response in crawl search.` {
+		t.Fatal("Expect JSON convert error")
+	}
+}
+
+// HTTPレスポンスがエラーとなっているのをテスト
+func TestGetCrawlIdReturnError(t *testing.T) {
+	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{400, []byte("result body"), nil}
+	httpreqmock.HttpResponseMockErr = errors.New("Error test")
 
 	httpRequestHandler = httpreqmock.HttpRequestData{}
 	scanSetting := args.ScanSetting{}
-	result, err := doCrawlSearch(scanSetting)
+	result, _, err := GetCrawlId(scanSetting)
 	fmt.Println(result)
-	if err != nil {
-		t.Fail()
+	if err == nil {
+		t.Error("Expect error response status.")
 	}
 }

--- a/src/vaddy/crawl/search_crawl_test.go
+++ b/src/vaddy/crawl/search_crawl_test.go
@@ -2,7 +2,6 @@ package crawl
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 	"vaddy/args"
 	"vaddy/httpreq"
@@ -77,8 +76,7 @@ func TestGetCrawlIdReturnError(t *testing.T) {
 
 	httpRequestHandler = httpreqmock.HttpRequestData{}
 	scanSetting := args.ScanSetting{}
-	result, _, err := GetCrawlId(scanSetting)
-	fmt.Println(result)
+	_, _, err := GetCrawlId(scanSetting)
 	if err == nil {
 		t.Error("Expect error response status.")
 	}

--- a/src/vaddy/httpreq/http.go
+++ b/src/vaddy/httpreq/http.go
@@ -42,7 +42,9 @@ func (hrd HttpRequestData) HttpGet(urlpath string, scanSetting args.ScanSetting,
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	defer resp.Body.Close()
+	if err == nil {
+		defer resp.Body.Close()
+	}
 
 	return getResponseData(resp, err), err
 }
@@ -64,12 +66,22 @@ func (hrd HttpRequestData) HttpPost(urlpath string, scanSetting args.ScanSetting
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	defer resp.Body.Close()
+	if err == nil {
+		defer resp.Body.Close()
+	}
 
 	return getResponseData(resp, err), err
 }
 
 func getResponseData(resp *http.Response, httpError error) HttpResponseData {
+	if httpError != nil {
+		return HttpResponseData{
+			Status: 500,
+			Body:   []byte(`Can not connect API server`),
+			Error:  httpError,
+		}
+	}
+
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	return HttpResponseData{

--- a/src/vaddy/httpreq/http.go
+++ b/src/vaddy/httpreq/http.go
@@ -13,6 +13,11 @@ import (
 	"vaddy/config"
 )
 
+type HttpReqInterface interface {
+	HttpGet(urlpath string, scanSetting args.ScanSetting, values url.Values) (HttpResponseData, error)
+	HttpPost(urlpath string, scanSetting args.ScanSetting, values url.Values) (HttpResponseData, error)
+}
+
 type HttpRequestData struct {
 }
 

--- a/src/vaddy/scan/check_scan_result.go
+++ b/src/vaddy/scan/check_scan_result.go
@@ -8,10 +8,9 @@ import (
 	"vaddy/args"
 	"vaddy/common"
 	"vaddy/config"
-	"vaddy/httpreq"
 )
 
-func GetScanResult(httpReq httpreq.HttpRequestData, scanSetting args.ScanSetting, scanId string) (ScanResult, error) {
+func GetScanResult(scanSetting args.ScanSetting, scanId string) (ScanResult, error) {
 	values := url.Values{}
 	values.Add("user", scanSetting.User)
 	values.Add("fqdn", scanSetting.Fqdn)
@@ -22,7 +21,7 @@ func GetScanResult(httpReq httpreq.HttpRequestData, scanSetting args.ScanSetting
 	var scanResult ScanResult
 	var retryCount int = 0
 	for {
-		result, err := httpReq.HttpGet("/scan/result", scanSetting, values)
+		result, err := httpRequestHandler.HttpGet("/scan/result", scanSetting, values)
 		if err != nil {
 			fmt.Print("HTTP Get Request Error: /scan/result. ")
 			fmt.Print(err)

--- a/src/vaddy/scan/check_scan_result.go
+++ b/src/vaddy/scan/check_scan_result.go
@@ -36,7 +36,10 @@ func GetScanResult(scanSetting args.ScanSetting, scanId string) (ScanResult, err
 		}
 
 		if err == nil && err2 == nil {
-			common.ConvertJsonToStruct(result.Body, &scanResult)
+			err := common.ConvertJsonToStruct(result.Body, &scanResult)
+			if err != nil {
+				return ScanResult{}, err
+			}
 			return scanResult, nil
 		}
 

--- a/src/vaddy/scan/check_scan_result_test.go
+++ b/src/vaddy/scan/check_scan_result_test.go
@@ -1,0 +1,92 @@
+package scan
+
+import (
+	"strconv"
+	"testing"
+	"vaddy/args"
+	"vaddy/httpreq"
+	"vaddy/test/mock/httpreqmock"
+)
+
+// 正常な検査完了レスポンスが返るテスト
+func TestCheckScanResultOk_ScanFinished(t *testing.T) {
+	var jsonResponse string = `{ "status":"finish",
+  "project_id" : "6eb1f9fcbdb6a5a",
+  "scan_id" : "1-837b5f9f-e088-4af5-9491-67f7ce8035a4",
+  "scan_count" : 22,
+  "alert_count" : 1,
+  "timezone" : "UTC",
+  "start_time" :  "2014-06-12T11:11:11+0000",
+  "end_time" :  "2014-06-12T11:11:11+0000",
+  "scan_result_url" : "https://console.vaddy.net/scan_status/1/1-837b5f9f-e088-4af5-9491-67f7ce8035a4",
+  "complete" : 100,
+  "crawl_id" : 30,
+  "crawl_label" : "ユーザ情報修正シナリオ",
+  "scan_list" : ["XSS","SQL Injection"]
+}`
+	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{200, []byte(jsonResponse), nil}
+	httpRequestHandler = httpreqmock.HttpRequestData{} //scan_http_request_hander.go global var HttpRequestHander
+	scanSetting := args.ScanSetting{}
+	result, err := GetScanResult(scanSetting, "1-837b5f9f-e088-4af5-9491-67f7ce8035a4")
+
+	if err != nil {
+		t.Error("err is not nil. " + err.Error())
+	}
+	if !result.IsFinished() {
+		t.Error("Scan Results not finish")
+	}
+	if !result.IsVulnExist() {
+		t.Error("Scan Results alert count error. alert count: " + strconv.Itoa(result.AlertCount))
+	}
+}
+
+// 検査がキャンセルされた結果が返るテスト
+func TestCheckScanResultOk_ScanCanceled(t *testing.T) {
+	var jsonResponse string = `{"status":"canceled"}`
+	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{200, []byte(jsonResponse), nil}
+	httpRequestHandler = httpreqmock.HttpRequestData{} //scan_http_request_hander.go global var HttpRequestHander
+	scanSetting := args.ScanSetting{}
+	result, err := GetScanResult(scanSetting, "1-837b5f9f-e088-4af5-9491-67f7ce8035a4")
+
+	if err != nil {
+		t.Error("err is not nil. " + err.Error())
+	}
+	if !result.IsCanceled() {
+		t.Error("Scan Results not cancel")
+	}
+}
+
+// 検査実行中の結果が返るテスト
+func TestCheckScanResultOk_ScanScanning(t *testing.T) {
+	var jsonResponse string = `{"status":"scanning"}`
+	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{200, []byte(jsonResponse), nil}
+	httpRequestHandler = httpreqmock.HttpRequestData{} //scan_http_request_hander.go global var HttpRequestHander
+	scanSetting := args.ScanSetting{}
+	result, err := GetScanResult(scanSetting, "1-837b5f9f-e088-4af5-9491-67f7ce8035a4")
+
+	if err != nil {
+		t.Error("err is not nil. " + err.Error())
+	}
+	if !result.IsScanRunning() {
+		t.Error("Scan Results not running")
+	}
+}
+
+// ネットワークやサーバエラーで5回リトライをテスト
+func TestCheckScanResultOk_ScanError(t *testing.T) {
+	var jsonResponse string = `{"error_message":"xxxxxx"}`
+	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{400, []byte(jsonResponse), nil}
+	httpRequestHandler = httpreqmock.HttpRequestData{} //scan_http_request_hander.go global var HttpRequestHander
+	scanSetting := args.ScanSetting{}
+	result, err := GetScanResult(scanSetting, "1-837b5f9f-e088-4af5-9491-67f7ce8035a4")
+
+	if err == nil {
+		t.Error("err is nil.")
+	}
+	if err.Error() != `Error: get scan result retry over.` {
+		t.Error("Expect retry over error message")
+	}
+	if result.Status != "" {
+		t.Error("scan status expect empty")
+	}
+}

--- a/src/vaddy/scan/scan_http_request_handler.go
+++ b/src/vaddy/scan/scan_http_request_handler.go
@@ -1,0 +1,6 @@
+package scan
+
+import "vaddy/httpreq"
+
+// scanパッケージ内で共有するHTTPリクエスト/レスポンスを扱うグローバル変数
+var httpRequestHandler httpreq.HttpReqInterface = httpreq.HttpRequestData{}

--- a/src/vaddy/scan/start_scan.go
+++ b/src/vaddy/scan/start_scan.go
@@ -11,7 +11,7 @@ type ScanId struct {
 	ScanID string `json:"scan_id"`
 }
 
-func StartScan(scanSetting args.ScanSetting) (string, error) {
+func StartScan(scanSetting args.ScanSetting) (scanIdString string, errorVal error) {
 	values := url.Values{}
 	values.Add("action", "start")
 	values.Add("user", scanSetting.User)
@@ -38,7 +38,7 @@ func StartScan(scanSetting args.ScanSetting) (string, error) {
 	return scanId, nil
 }
 
-func getScanId(jsonByteData []byte) string {
+func getScanId(jsonByteData []byte) (scanIdString string) {
 	var scan_result ScanId
 	common.ConvertJsonToStruct(jsonByteData, &scan_result)
 	return scan_result.ScanID

--- a/src/vaddy/scan/start_scan.go
+++ b/src/vaddy/scan/start_scan.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"errors"
 	"net/url"
 	"vaddy/args"
 	"vaddy/common"
@@ -31,6 +32,9 @@ func StartScan(scanSetting args.ScanSetting) (string, error) {
 	}
 	scanId := getScanId(result.Body)
 	//fmt.Println("scanId: " + scanId)
+	if scanId == "" {
+		return "", errors.New("StartScan Error: No Scan ID found.")
+	}
 	return scanId, nil
 }
 

--- a/src/vaddy/scan/start_scan.go
+++ b/src/vaddy/scan/start_scan.go
@@ -4,14 +4,13 @@ import (
 	"net/url"
 	"vaddy/args"
 	"vaddy/common"
-	"vaddy/httpreq"
 )
 
 type ScanId struct {
 	ScanID string `json:"scan_id"`
 }
 
-func StartScan(httpReq httpreq.HttpRequestData, scanSetting args.ScanSetting) (string, error) {
+func StartScan(scanSetting args.ScanSetting) (string, error) {
 	values := url.Values{}
 	values.Add("action", "start")
 	values.Add("user", scanSetting.User)
@@ -21,7 +20,7 @@ func StartScan(httpReq httpreq.HttpRequestData, scanSetting args.ScanSetting) (s
 	values.Add("scan_type", scanSetting.ScanType)
 	values.Add("crawl_id", scanSetting.CrawlId)
 
-	result, err := httpReq.HttpPost("/scan", scanSetting, values)
+	result, err := httpRequestHandler.HttpPost("/scan", scanSetting, values)
 	if err != nil {
 		return "", err
 	}

--- a/src/vaddy/scan/start_scan_test.go
+++ b/src/vaddy/scan/start_scan_test.go
@@ -1,0 +1,87 @@
+package scan
+
+import (
+	"errors"
+	"testing"
+	"vaddy/args"
+	"vaddy/httpreq"
+	"vaddy/test/mock/httpreqmock"
+)
+
+func TestStartScanOK(t *testing.T) {
+	var jsonResponse string = `{"scan_id": "vaddy-scanid-12345"}`
+	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{200, []byte(jsonResponse), nil}
+	httpRequestHandler = httpreqmock.HttpRequestData{} //scan_http_request_hander.go global var HttpRequestHander
+	scanSetting := args.ScanSetting{}
+	scanId, err := StartScan(scanSetting)
+
+	if err != nil {
+		t.Error("err is not nil")
+	}
+	if scanId != "vaddy-scanid-12345" {
+		t.Error("scanId check error")
+	}
+}
+
+//HTTP statusが400で、あえてレスポンスのMockErrにnilをセットしてエラーを検証
+func TestStartScanNG_checkResponseStatus400(t *testing.T) {
+	var jsonResponse string = `{"error_message":"error response"}`
+	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{400, []byte(jsonResponse), nil}
+	httpreqmock.HttpResponseMockErr = nil
+
+	scanSetting := args.ScanSetting{}
+	scanId, err := StartScan(scanSetting)
+
+	if err == nil {
+		t.Error("err is nil")
+	}
+	if scanId != "" {
+		t.Error("scanId not empty. expect empty")
+	}
+
+	errorMessage := `Network/Auth error
+{"error_message":"error response"}`
+
+	if err.Error() != errorMessage {
+		t.Fatal(err.Error())
+	}
+}
+
+// レスポンス200だがScanIDが見つからないレスポンスbodyを返してエラーをチェック
+func TestStartScanNG_checkBrokenJson(t *testing.T) {
+	var jsonResponse string = `{"error_message"`
+	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{200, []byte(jsonResponse), nil}
+	httpreqmock.HttpResponseMockErr = nil
+
+	scanSetting := args.ScanSetting{}
+	scanId, err := StartScan(scanSetting)
+
+	if err == nil {
+		t.Error("err is nil")
+	}
+	if err.Error() != `StartScan Error: No Scan ID found.` {
+		t.Fatal(err.Error())
+	}
+	if scanId != "" {
+		t.Error("scanId not empty. expect empty")
+	}
+}
+
+//MockErrにエラーをセットしてエラーチェック
+func TestStartScanNG2_checkErrorReturn(t *testing.T) {
+	var jsonResponse string = `{"error_message":"test error"}`
+	httpreqmock.HttpResponseMock = httpreq.HttpResponseData{400, []byte(jsonResponse), nil}
+	httpreqmock.HttpResponseMockErr = errors.New("Error test")
+	scanSetting := args.ScanSetting{}
+	scanId, err := StartScan(scanSetting)
+
+	if err == nil {
+		t.Error("err is nil")
+	}
+	if scanId != "" {
+		t.Error("scanId not empty. expect empty")
+	}
+	if err.Error() != `Error test` {
+		t.Fatal(err.Error())
+	}
+}

--- a/src/vaddy/test/mock/httpreqmock/http.go
+++ b/src/vaddy/test/mock/httpreqmock/http.go
@@ -1,0 +1,20 @@
+package httpreqmock
+
+import (
+	"net/url"
+	"vaddy/args"
+	"vaddy/httpreq"
+)
+
+type HttpRequestData struct {
+}
+
+var HttpResponseMock = httpreq.HttpResponseData{}
+var HttpResponseMockErr error = nil
+
+func (hrd HttpRequestData) HttpGet(urlpath string, scanSetting args.ScanSetting, values url.Values) (httpreq.HttpResponseData, error) {
+	return HttpResponseMock, HttpResponseMockErr
+}
+func (hrd HttpRequestData) HttpPost(urlpath string, scanSetting args.ScanSetting, values url.Values) (httpreq.HttpResponseData, error) {
+	return HttpResponseMock, HttpResponseMockErr
+}

--- a/src/vaddy/vaddy.go
+++ b/src/vaddy/vaddy.go
@@ -43,11 +43,13 @@ func main() {
 
 	if scanSetting.CheckNeedToGetCrawlId() {
 		fmt.Println("Start to get crawl ID from keyword: " + scanSetting.Crawl)
-		scanSetting.CrawlId, err = crawl.GetCrawlId(scanSetting)
+		var crawlTotalCount int
+		scanSetting.CrawlId, crawlTotalCount, err = crawl.GetCrawlId(scanSetting)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(ERROR_EXIT)
 		}
+		fmt.Printf("Found %d crawl results. Using CrawlID: %s \n\n", crawlTotalCount, scanSetting.CrawlId)
 	}
 
 	scanId, err := scan.StartScan(scanSetting)

--- a/src/vaddy/vaddy.go
+++ b/src/vaddy/vaddy.go
@@ -10,7 +10,6 @@ import (
 	"vaddy/common"
 	"vaddy/config"
 	"vaddy/crawl"
-	"vaddy/httpreq"
 	"vaddy/notification"
 	"vaddy/scan"
 )
@@ -44,14 +43,14 @@ func main() {
 
 	if scanSetting.CheckNeedToGetCrawlId() {
 		fmt.Println("Start to get crawl ID from keyword: " + scanSetting.Crawl)
-		scanSetting.CrawlId, err = crawl.GetCrawlId(httpreq.HttpRequestData{}, scanSetting)
+		scanSetting.CrawlId, err = crawl.GetCrawlId(scanSetting)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(ERROR_EXIT)
 		}
 	}
 
-	scanId, err := scan.StartScan(httpreq.HttpRequestData{}, scanSetting)
+	scanId, err := scan.StartScan(scanSetting)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(ERROR_EXIT)
@@ -60,7 +59,7 @@ func main() {
 
 	var waitCount int = 0
 	for {
-		scanResult, err := scan.GetScanResult(httpreq.HttpRequestData{}, scanSetting, scanId)
+		scanResult, err := scan.GetScanResult(scanSetting, scanId)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(ERROR_EXIT)


### PR DESCRIPTION
APIサーバと通信してJSONを取得して処理をする箇所のテストケースを作成。
全てMockを使って実際のHTTP通信は発生しないようにした。

Create a test case for the part that communicates with the API server, acquires JSON, and processes it.
All Mocks were used to prevent actual HTTP communication from occurring.